### PR TITLE
Fix read_pgm_image by opening input file as binary

### DIFF
--- a/canny_baseline/canny_source.c
+++ b/canny_baseline/canny_source.c
@@ -917,7 +917,7 @@ int read_pgm_image(char *infilename, unsigned char **image, int *rows,
    ***************************************************************************/
    if(infilename == NULL) fp = stdin;
    else{
-      if((fp = fopen(infilename, "r")) == NULL){
+      if((fp = fopen(infilename, "rb")) == NULL){
          fprintf(stderr, "Error reading the file %s in read_pgm_image().\n",
             infilename);
          return(0);


### PR DESCRIPTION
The code was not working since the provided PGM file is a binary PGM file and the file was open as a text file.